### PR TITLE
ProcDump command to take a full dump only on StackOverflowException

### DIFF
--- a/NETExceptionGenerator/ProcDump/ProcDumpCommands.cmd
+++ b/NETExceptionGenerator/ProcDump/ProcDumpCommands.cmd
@@ -1,0 +1,1 @@
+procdump.exe -ma NETFullConsoleExceptionGenerator -o c:\_Temp -e 1 -n 10 -f "System.StackOverflowException"


### PR DESCRIPTION
ProcDump will take only dump for a specific .NET first chance Exception "System.StackOverflowException"